### PR TITLE
fixes-for-aggregation-and-change-key-for-nodes

### DIFF
--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ type Configuration struct {
 		CACertificates string            `yaml:"caCertificates"`
 		Username       string            `yaml:"username" validate:"required"`
 		Password       string            `yaml:"password" validate:"required"`
-		Key						 string            `yaml:"key" validate:"required"`
+		Key            string            `yaml:"key" validate:"required"`
 		Labels         map[string]string `yaml:"labels"`
 	} `yaml:"nodes" validate:"required,dive"`
 }
@@ -108,7 +108,7 @@ func start(config *Configuration) error {
 			"labels":   node.Labels,
 			"url":      node.URL,
 			"username": node.Username,
-			"key":			node.Key,
+			"key":      node.Key,
 		}).Info("Registering NiFi node...")
 		if err := prometheus.DefaultRegisterer.Register(collectors.NewDiagnosticsCollector(api, node.Labels, node.Key)); err != nil {
 			return errors.Annotate(err, "Couldn't register system diagnostics collector.")

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ type Configuration struct {
 		CACertificates string            `yaml:"caCertificates"`
 		Username       string            `yaml:"username" validate:"required"`
 		Password       string            `yaml:"password" validate:"required"`
+		Key						 string            `yaml:"key" validate:"required"`
 		Labels         map[string]string `yaml:"labels"`
 	} `yaml:"nodes" validate:"required,dive"`
 }
@@ -107,14 +108,15 @@ func start(config *Configuration) error {
 			"labels":   node.Labels,
 			"url":      node.URL,
 			"username": node.Username,
+			"key":			node.Key,
 		}).Info("Registering NiFi node...")
-		if err := prometheus.DefaultRegisterer.Register(collectors.NewDiagnosticsCollector(api, node.Labels)); err != nil {
+		if err := prometheus.DefaultRegisterer.Register(collectors.NewDiagnosticsCollector(api, node.Labels, node.Key)); err != nil {
 			return errors.Annotate(err, "Couldn't register system diagnostics collector.")
 		}
-		if err := prometheus.DefaultRegisterer.Register(collectors.NewCountersCollector(api, node.Labels)); err != nil {
+		if err := prometheus.DefaultRegisterer.Register(collectors.NewCountersCollector(api, node.Labels, node.Key)); err != nil {
 			return errors.Annotate(err, "Couldn't register counters collector.")
 		}
-		if err := prometheus.DefaultRegisterer.Register(collectors.NewProcessGroupsCollector(api, node.Labels)); err != nil {
+		if err := prometheus.DefaultRegisterer.Register(collectors.NewProcessGroupsCollector(api, node.Labels, node.Key)); err != nil {
 			return errors.Annotate(err, "Couldn't register process groups collector.")
 		}
 		if err := prometheus.DefaultRegisterer.Register(collectors.NewConnectionsCollector(api, node.Labels)); err != nil {

--- a/nifi/client/client.go
+++ b/nifi/client/client.go
@@ -87,7 +87,7 @@ func (c *Client) GetCounters(nodewise bool, clusterNodeId string) (*CountersDTO,
 	if nodewise {
 		query.Add("nodewise", "true")
 	} else {
-		query.Add("nodewise", "0")
+		query.Add("nodewise", "false")
 	}
 	if len(clusterNodeId) > 0 {
 		query.Add("clusterNodeId", clusterNodeId)
@@ -182,7 +182,7 @@ func (c *Client) GetSystemDiagnostics(nodewise bool, clusterNodeId string) (*Sys
 	if nodewise {
 		query.Add("nodewise", "true")
 	} else {
-		query.Add("nodewise", "0")
+		query.Add("nodewise", "false")
 	}
 	if len(clusterNodeId) > 0 {
 		query.Add("clusterNodeId", clusterNodeId)

--- a/nifi/client/client.go
+++ b/nifi/client/client.go
@@ -85,7 +85,7 @@ func NewClient(baseURL, username, password, caCertificates string) (*Client, err
 func (c *Client) GetCounters(nodewise bool, clusterNodeId string) (*CountersDTO, error) {
 	query := url.Values{}
 	if nodewise {
-		query.Add("nodewise", "1")
+		query.Add("nodewise", "true")
 	} else {
 		query.Add("nodewise", "0")
 	}
@@ -180,7 +180,7 @@ func (c *Client) getDeepProcessGroups(parentID string, groupsEntity *ProcessGrou
 func (c *Client) GetSystemDiagnostics(nodewise bool, clusterNodeId string) (*SystemDiagnosticsDTO, error) {
 	query := url.Values{}
 	if nodewise {
-		query.Add("nodewise", "1")
+		query.Add("nodewise", "true")
 	} else {
 		query.Add("nodewise", "0")
 	}

--- a/nifi/collectors/counters.go
+++ b/nifi/collectors/counters.go
@@ -8,13 +8,15 @@ import (
 
 type CountersCollector struct {
 	alias              string
+	key 							 string
 	api                *client.Client
 	counterTotalMetric *prometheus.Desc
 }
 
-func NewCountersCollector(api *client.Client, labels map[string]string) *CountersCollector {
+func NewCountersCollector(api *client.Client, labels map[string]string, key string) *CountersCollector {
 	return &CountersCollector{
 		api: api,
+		key: key,
 		counterTotalMetric: prometheus.NewDesc(
 			MetricNamePrefix+"counter_total",
 			"The value of the counter.",
@@ -42,7 +44,13 @@ func (c *CountersCollector) Collect(ch chan<- prometheus.Metric) {
 	if len(counterStats.NodeSnapshots) > 0 {
 		for i := range counterStats.NodeSnapshots {
 			snapshot := &counterStats.NodeSnapshots[i]
-			nodes[snapshot.NodeID] = snapshot.Snapshot.Counters
+
+			if c.key == "address" {
+				nodes[snapshot.Address] = snapshot.Snapshot.Counters
+		} else {
+				nodes[snapshot.NodeID] = snapshot.Snapshot.Counters
+			}
+
 		}
 	} else if counterStats.AggregateSnapshot != nil {
 		nodes[AggregateNodeID] = counterStats.AggregateSnapshot.Counters

--- a/nifi/collectors/counters.go
+++ b/nifi/collectors/counters.go
@@ -8,7 +8,7 @@ import (
 
 type CountersCollector struct {
 	alias              string
-	key 							 string
+	key                string
 	api                *client.Client
 	counterTotalMetric *prometheus.Desc
 }

--- a/nifi/collectors/counters.go
+++ b/nifi/collectors/counters.go
@@ -47,7 +47,7 @@ func (c *CountersCollector) Collect(ch chan<- prometheus.Metric) {
 
 			if c.key == "address" {
 				nodes[snapshot.Address] = snapshot.Snapshot.Counters
-		} else {
+			} else {
 				nodes[snapshot.NodeID] = snapshot.Snapshot.Counters
 			}
 

--- a/nifi/collectors/diagnostics.go
+++ b/nifi/collectors/diagnostics.go
@@ -212,7 +212,7 @@ func (c *DiagnosticsCollector) Collect(ch chan<- prometheus.Metric) {
 	if len(diagnostics.NodeSnapshots) > 0 {
 		for i := range diagnostics.NodeSnapshots {
 			snapshot := &diagnostics.NodeSnapshots[i]
-			nodes[snapshot.NodeID] = &snapshot.Snapshot
+			nodes[snapshot.Address] = &snapshot.Snapshot
 		}
 	} else if diagnostics.AggregateSnapshot != nil {
 		nodes[AggregateNodeID] = diagnostics.AggregateSnapshot

--- a/nifi/collectors/diagnostics.go
+++ b/nifi/collectors/diagnostics.go
@@ -217,10 +217,10 @@ func (c *DiagnosticsCollector) Collect(ch chan<- prometheus.Metric) {
 
 			if c.key == "address" {
 				nodes[snapshot.Address] = &snapshot.Snapshot
-		} else {
+			} else {
 				nodes[snapshot.NodeID] = &snapshot.Snapshot
 			}
-			
+
 		}
 	} else if diagnostics.AggregateSnapshot != nil {
 		nodes[AggregateNodeID] = diagnostics.AggregateSnapshot

--- a/nifi/collectors/diagnostics.go
+++ b/nifi/collectors/diagnostics.go
@@ -36,18 +36,20 @@ type storageMetrics struct {
 
 type DiagnosticsCollector struct {
 	api *client.Client
+	key string
 
 	generalMetrics
 	jvmMetrics
 	storageMetrics
 }
 
-func NewDiagnosticsCollector(api *client.Client, labels map[string]string) *DiagnosticsCollector {
+func NewDiagnosticsCollector(api *client.Client, labels map[string]string, key string) *DiagnosticsCollector {
 	basicLabels := []string{"node_id"}
 	jvmMetricsPrefix := MetricNamePrefix + "jvm_"
 	storageMetricsPrefix := MetricNamePrefix + "stor_"
 	return &DiagnosticsCollector{
 		api: api,
+		key: key,
 
 		generalMetrics: generalMetrics{
 			info: prometheus.NewDesc(
@@ -212,7 +214,13 @@ func (c *DiagnosticsCollector) Collect(ch chan<- prometheus.Metric) {
 	if len(diagnostics.NodeSnapshots) > 0 {
 		for i := range diagnostics.NodeSnapshots {
 			snapshot := &diagnostics.NodeSnapshots[i]
-			nodes[snapshot.Address] = &snapshot.Snapshot
+
+			if c.key == "address" {
+				nodes[snapshot.Address] = &snapshot.Snapshot
+		} else {
+				nodes[snapshot.NodeID] = &snapshot.Snapshot
+			}
+			
 		}
 	} else if diagnostics.AggregateSnapshot != nil {
 		nodes[AggregateNodeID] = diagnostics.AggregateSnapshot

--- a/nifi/collectors/processgroups.go
+++ b/nifi/collectors/processgroups.go
@@ -203,7 +203,7 @@ func (c *ProcessGroupsCollector) collect(ch chan<- prometheus.Metric, entity *cl
 
 			if c.key == "address" {
 				nodes[snapshot.Address] = &snapshot.StatusSnapshot
-		  } else {
+			} else {
 				nodes[snapshot.NodeID] = &snapshot.StatusSnapshot
 			}
 

--- a/nifi/collectors/processgroups.go
+++ b/nifi/collectors/processgroups.go
@@ -203,7 +203,7 @@ func (c *ProcessGroupsCollector) collect(ch chan<- prometheus.Metric, entity *cl
 
 			if c.key == "address" {
 				nodes[snapshot.Address] = &snapshot.StatusSnapshot
-		} else {
+		  } else {
 				nodes[snapshot.NodeID] = &snapshot.StatusSnapshot
 			}
 

--- a/nifi/collectors/processgroups.go
+++ b/nifi/collectors/processgroups.go
@@ -7,6 +7,7 @@ import (
 
 type ProcessGroupsCollector struct {
 	api *client.Client
+	key string
 
 	bulletin5mCount *prometheus.Desc
 	componentCount  *prometheus.Desc
@@ -28,11 +29,12 @@ type ProcessGroupsCollector struct {
 	activeThreadCount           *prometheus.Desc
 }
 
-func NewProcessGroupsCollector(api *client.Client, labels map[string]string) *ProcessGroupsCollector {
+func NewProcessGroupsCollector(api *client.Client, labels map[string]string, key string) *ProcessGroupsCollector {
 	prefix := MetricNamePrefix + "pg_"
 	statLabels := []string{"node_id", "group", "entity_id"}
 	return &ProcessGroupsCollector{
 		api: api,
+		key: key,
 
 		bulletin5mCount: prometheus.NewDesc(
 			prefix+"bulletin_5m_count",
@@ -198,7 +200,13 @@ func (c *ProcessGroupsCollector) collect(ch chan<- prometheus.Metric, entity *cl
 	if len(entity.Status.NodeSnapshots) > 0 {
 		for i := range entity.Status.NodeSnapshots {
 			snapshot := &entity.Status.NodeSnapshots[i]
-			nodes[snapshot.NodeID] = &snapshot.StatusSnapshot
+
+			if c.key == "address" {
+				nodes[snapshot.Address] = &snapshot.StatusSnapshot
+		} else {
+				nodes[snapshot.NodeID] = &snapshot.StatusSnapshot
+			}
+
 		}
 	} else if entity.Status.AggregateSnapshot != nil {
 		nodes[AggregateNodeID] = entity.Status.AggregateSnapshot

--- a/sample-config.yml
+++ b/sample-config.yml
@@ -5,11 +5,13 @@ nodes:
   - url: http://test-nifi.example.com:8080
     username: nifitest
     password: abc123
+    key: address
     labels:
       env: testing
   - url: https://nifi.example.com
     username: nifiuser
     password: 123456
+    key: address
     labels:
       env: production
     caCertificates: |


### PR DESCRIPTION
Added parameter **key** in config file to control **node_id** in Prometheus metrics.
Changed requests from _nifi-api/*?nodewise=1_ to _nifi-api/*?nodewise=true_ and _nifi-api/*?nodewise=0_ to _nifi-api/*?nodewise=false_. 